### PR TITLE
Switch Gold Runner to Trillium San Joaquins feed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,7 +504,7 @@ fn feature_to_gtfs_unified(
 
     let route_id: Option<String> = match route_name {
         Some(route_name) => match route_name.as_str() {
-            "Gold Runner" => Some("SJ2".to_string()),
+            "Gold Runner" => Some("13510".to_string()),
             _ => long_name_to_route_id_hashmap
                 .get(&route_name.clone())
                 .cloned(),


### PR DESCRIPTION
This makes it compatible with https://data.trilliumtransit.com/gtfs/sanjoaquins-ca-us/sanjoaquins-ca-us.zip.

This is incomplete.

TODO:
* [ ] We may want to put Gold Runner in its own chateau
* [ ] Use the trillium feed in transitland-atlas
* [ ] Get rid of the Gold Runner special-cases in catenary-backend
* [ ] Pass the Trillium San Joaquins GTFS to amtrak-gtfs-rt in catenary-backend